### PR TITLE
Ensure clean build before all publishes. Add tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "types": "lib/dom-element-getter-helpers.d.ts",
   "scripts": {
     "build": "babel src/dom-element-getter-helpers.ts --out-file lib/dom-element-getter-helpers.js && tsc",
+    "clean": "rimraf lib",
     "test": "cross-env BABEL_ENV=test jest --config jest.config.cjs",
     "format": "prettier --write .",
     "check-format": "prettier --check .",
+    "prepublishOnly": "pnpm run clean && pnpm run build",
     "prepare": "husky install"
   },
   "repository": {
@@ -44,6 +46,7 @@
     "jest": "^27.2.1",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.1",
+    "rimraf": "^3.0.2",
     "typescript": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ specifiers:
   jest: ^27.2.1
   prettier: ^2.4.1
   pretty-quick: ^3.1.1
+  rimraf: ^3.0.2
   single-spa: ^5.9.3
   typescript: ^4.4.3
 
@@ -32,6 +33,7 @@ devDependencies:
   jest: 27.2.1
   prettier: 2.4.1
   pretty-quick: 3.1.1_prettier@2.4.1
+  rimraf: 3.0.2
   typescript: 4.4.3
 
 packages:

--- a/src/dom-element-getter-helpers.test.ts
+++ b/src/dom-element-getter-helpers.test.ts
@@ -84,4 +84,20 @@ describe("dom-element-getter-helpers", () => {
     const domElementGetter = chooseDomElementGetter(opts, props);
     expect(domElementGetter).toThrowError(/returned an invalid dom element/);
   });
+
+  it("passes props to opts.domElementGetter", () => {
+    opts.domElementGetter = jest
+      .fn()
+      .mockImplementation(() => document.createElement("div"));
+    chooseDomElementGetter(opts, props)();
+    expect(opts.domElementGetter).toHaveBeenCalledWith(props);
+  });
+
+  it("passes props to props.domElementGetter", () => {
+    props.domElementGetter = jest
+      .fn()
+      .mockImplementation(() => document.createElement("div"));
+    chooseDomElementGetter(opts, props)();
+    expect(props.domElementGetter).toHaveBeenCalledWith(props);
+  });
 });


### PR DESCRIPTION
dom-element-getter-helpers@1.1.0 was a bad publish - I forgot to manually run `pnpm run build` before publishing. But we shouldn't need to do that manual step, it can be done in prepublishOnly. So I've added that. I also had written some tests trying to debug a bug with v1.0.0 but then realized the publish problem. I kept the tests because they're useful even though they didn't reveal a problem with the source code (only the published code)