### PR TITLE
Fixed TS issues when used with `single-spa-react`

### DIFF
--- a/src/dom-element-getter-helpers.ts
+++ b/src/dom-element-getter-helpers.ts
@@ -8,7 +8,7 @@ type AllProps<ExtraProps = {}> = AppProps &
     appName?: string;
   };
 
-interface HelperOpts<ExtraProps> {
+interface HelperOpts<ExtraProps = {}> {
   domElementGetter?(props?: ExtraProps): HTMLElement;
 }
 


### PR DESCRIPTION
## Description

Hi there! 👋 

For a private project, we're using the `single-spa-react` package, and wanted to use this new helper package to not have to reproduce the logic to mount a parcel. It's working as expected, but as we are using Typescript for this project, it is complaining that the definitions for `domElementGetter` between `single-spa-react` and `dom-element-getter-helpers` don't match. For reference, here's [the definition from `single-spa-react`](https://github.com/single-spa/single-spa-react/blob/010e21a9a0693a0effd793f8fe9933bb090fbc1d/types/single-spa-react.d.ts#L27). I think the React ecosystem is the only one that passes props to this function.

Since the `domElementGetter` now takes an optional `props` parameter, it should still work as expected for other ecosystems that don't pass it. We've tested it in our project and the Typescript issue has disappeared.

All the tests are passing, there's no formatting issue and the project builds successfully.

Also, thank you for `single-spa` and all the helpers, it's awesome!

## Changes

- Updated `domElementGetter` function to take optional props